### PR TITLE
Removed some default packages from the manifest

### DIFF
--- a/Jam Starter/Packages/manifest.json
+++ b/Jam Starter/Packages/manifest.json
@@ -1,10 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ads": "2.3.1",
-    "com.unity.analytics": "3.2.2",
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.package-manager-ui": "2.0.3",
-    "com.unity.purchasing": "2.0.3",
     "com.unity.textmeshpro": "1.3.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
These packages are just bloat for jam games
Removed:
	- Advertisement
	- Analytics Library
	- In App Purchasing
Retained Unity Collaborate and TextMeshPro as they can be beneficial
during a jam